### PR TITLE
fix(hint): use correct color

### DIFF
--- a/themes/jetbrains-dark.json
+++ b/themes/jetbrains-dark.json
@@ -252,7 +252,7 @@
             "font_weight": null
           },
           "hint": {
-            "color": "#ff00ff",
+            "color": "#868a91",
             "font_style": null,
             "font_weight": 700
           },

--- a/themes/jetbrains-light.json
+++ b/themes/jetbrains-light.json
@@ -252,7 +252,7 @@
             "font_weight": null
           },
           "hint": {
-            "color": "#ff00ff",
+            "color": "#7a7a7a",
             "font_style": null,
             "font_weight": 700
           },


### PR DESCRIPTION
https://github.com/zed-industries/zed/issues/38951

Fix inlay hints using status theming instead of syntax theming:
https://github.com/zed-industries/zed/pull/36219

Since using Zed: v0.207.0 (Zed Nightly bcc8149), the hint color is incorrect
